### PR TITLE
Clean up block.py

### DIFF
--- a/blocks.py
+++ b/blocks.py
@@ -273,25 +273,20 @@ class Block(Mate, Mutate):
 
     def calculate_func_args_inputs(self):
         for node_index in self.active_nodes:
-            if node_index < 0:
-                # nothing to evaluate at input nodes
-                continue
-            elif node_index >= self.genome_main_count:
-                # nothing to evaluate at output nodes
+            if node_index < 0 or node_index >= self.genome_main_count:
+                # nothing to evaluate at input/output nodes
                 continue
             else:
-                # only thing left is main node...extract "ftn", "inputs", and "args" below
+                # calculate on main nodes
                 pass
-            # get function to evaluate
+            # get functioin, inputs, arguments to evaluate
             function = self[node_index]["ftn"]
-            # get inputs to function to evaluate
             inputs = []
             val_inputs = []
             node_input_indices = self[node_index]["inputs"]
             for node_input_index in node_input_indices:
                 inputs.append(self.evaluated[node_input_index])
                 val_inputs.append(self.val_evaluated[node_input_index])
-            # get arguments to function to evaluate
             args = []
             node_arg_indices = self[node_index]["args"]
             for node_arg_index in node_arg_indices:
@@ -314,9 +309,7 @@ class Block(Mate, Mutate):
 
     def tensorflow_evaluate(self, block_inputs, labels_all, validation_pair):
         data_pair = {}
-        for i, input_ in enumerate(block_inputs): #self.genome_input_dtypes):
-            # consider reading in the dataset with slices..."from_tensor_slices"
-            # then dataset.shuffle.repate.batch and dataset.make_one_shot_iterator
+        for i, input_ in enumerate(block_inputs):
             data_dimension = list(input_.shape)
             data_dimension[0] = None # variable input size, "how to tell tensorflow" to figure it out by def.
             with self.graph.as_default():

--- a/genome.py
+++ b/genome.py
@@ -1,6 +1,7 @@
 ### genome.py
 
 import numpy as np
+import logging
 
 class Genome():
 
@@ -90,7 +91,11 @@ class Genome():
         else:
             # then it's a Block Main Node
             pass
-        ftn = self[node_index]["ftn"]
+        try:
+            ftn = self[node_index]["ftn"]
+        except TypeError:
+            logging.info('Input/output dtype is incompatible with operator functions')
+            quit()
         ftn_dict = self.operator_dict[ftn]
         if input_dtype:
             # get the required input data types for this function
@@ -116,7 +121,7 @@ class Genome():
                 for c, choice in enumerate(choices):
                     if val==choice:
                         delete.append(c)
-        
+
             if len(choices) != 1:
                 print("Should not call mutate since only one function available. Returning original function")
 

--- a/problem.py
+++ b/problem.py
@@ -111,7 +111,7 @@ def scoreFunction(predict, actual):
         .format(x_train.shape, y_train.shape, x_test.shape, y_test.shape))
 
 """
-preprocessing_block = PreprocessingBlock(tensorblock_flag=False, apply_to_val = False, main_count=2) #input_dtypes = [tf.Tensor], output_dtypes = [tf.Tensor])
+preprocessing_block = PreprocessingBlock(tensorblock_flag=True, input_dtypes = [tf.Tensor], output_dtypes = [tf.Tensor], apply_to_val = False, main_count=2) #input_dtypes = [tf.Tensor], output_dtypes = [tf.Tensor])
 #print('preprocessing block: ', vars(preprocessing_block))
 
 training_block = TrainingBlock(main_count=2,learning_required=True, apply_to_val = False)

--- a/problem.py
+++ b/problem.py
@@ -111,10 +111,10 @@ def scoreFunction(predict, actual):
         .format(x_train.shape, y_train.shape, x_test.shape, y_test.shape))
 
 """
-preprocessing_block = PreprocessingBlock(tensorblock_flag=False, apply_to_val = False, main_count=40) #input_dtypes = [tf.Tensor], output_dtypes = [tf.Tensor])
+preprocessing_block = PreprocessingBlock(tensorblock_flag=False, apply_to_val = False, main_count=2) #input_dtypes = [tf.Tensor], output_dtypes = [tf.Tensor])
 #print('preprocessing block: ', vars(preprocessing_block))
 
-training_block = TrainingBlock(main_count=30,learning_required=True, apply_to_val = False)
+training_block = TrainingBlock(main_count=2,learning_required=True, apply_to_val = False)
 #print('training block: ', vars(training_block))
 
 skeleton_genome = { # this defines the WHOLE GENOME
@@ -124,8 +124,3 @@ skeleton_genome = { # this defines the WHOLE GENOME
     1: vars(preprocessing_block),
     2: vars(training_block)
 }
-
-
-logging.info(("Data X, Y:"))
-logging.info(x_test)
-logging.info(y_test)

--- a/tester.py
+++ b/tester.py
@@ -13,27 +13,27 @@ print('individual has fitness: {}'.format(individual.fitness.values))
 
 # print(individual.genome_outputs)
 # print(individual.dead)
-for i in range(1,individual.num_blocks+1):
-    curr_block = individual.skeleton[i]["block_object"]
-    # print('curr_block: {}'.format(curr_block))
-    arg_values = np.array(curr_block.args)
-    print('arg_values: {}'.format(arg_values))
-    print('curr_block isDead = ', curr_block.dead)
-    print(curr_block.active_nodes)
-    for active_node in curr_block.active_nodes:
-        fn = curr_block[active_node]
-        if active_node < 0:
-            # nothing to evaluate at input nodes
-            print('function at: {} is: {}'\
-                .format(active_node, fn))
-            continue
-        elif active_node >= curr_block.genome_main_count:
-            # nothing to evaluate at output nodes
-            print('function at: {} is: {} -> likely an output node'\
-                .format(active_node, fn))
-            continue
-        print('function at: {} is: {} and has arguments: {}'\
-                .format(active_node, fn, arg_values[fn['args']]))
+# for i in range(1,individual.num_blocks+1):
+#     curr_block = individual.skeleton[i]["block_object"]
+#     # print('curr_block: {}'.format(curr_block))
+#     arg_values = np.array(curr_block.args)
+#     print('arg_values: {}'.format(arg_values))
+#     print('curr_block isDead = ', curr_block.dead)
+#     print(curr_block.active_nodes)
+#     for active_node in curr_block.active_nodes:
+#         fn = curr_block[active_node]
+#         if active_node < 0:
+#             # nothing to evaluate at input nodes
+#             print('function at: {} is: {}'\
+#                 .format(active_node, fn))
+#             continue
+#         elif active_node >= curr_block.genome_main_count:
+#             # nothing to evaluate at output nodes
+#             print('function at: {} is: {} -> likely an output node'\
+#                 .format(active_node, fn))
+#             continue
+#         print('function at: {} is: {} and has arguments: {}'\
+#                 .format(active_node, fn, arg_values[fn['args']]))
 #
 # individual.mutate()
 # print('\n\nPOST MUTATE')

--- a/utils/preprocessing_block.py
+++ b/utils/preprocessing_block.py
@@ -17,9 +17,9 @@ class PreprocessingBlock(SkeletonBlock):
             #prob: float btwn 0 and 1 -> assigns that prob to that primitive...the sum can't be more than 1
             #prob: 1 -> equally distribute the remaining probability amoung all those remaining (hard to explain, sorry)
             self.setup_dict_ftn = {
-            #    operators.identity_layer: {"prob": 1}
-                 operators.gassuian_blur: {'prob': 1},
-                 operators.ceil_greyscale_norm: {'prob': 1}
+               operators.identity_layer: {"prob": 1}
+            #      operators.gassuian_blur: {'prob': 1},
+            #      operators.ceil_greyscale_norm: {'prob': 1}
             }
         else:
             # specific layers

--- a/utils/training_block.py
+++ b/utils/training_block.py
@@ -10,21 +10,21 @@ class TrainingBlock(SkeletonBlock):
         if "setup_dict_ftn" not in kwargs:
             # default layers
 
-            #declare which primitives are available to the genome,	
-            #and assign a 'prob' so that you can control how likely a primitive will be used;	
-            #prob: float btwn 0 and 1 -> assigns that prob to that primitive...the sum can't be more than 1	
-            #prob: 1 -> equally distribute the remaining probability amoung all those remaining (hard to explain, sorry)	
+            #declare which primitives are available to the genome,
+            #and assign a 'prob' so that you can control how likely a primitive will be used;
+            #prob: float btwn 0 and 1 -> assigns that prob to that primitive...the sum can't be more than 1
+            #prob: 1 -> equally distribute the remaining probability amoung all those remaining (hard to explain, sorry)
             self.setup_dict_ftn = {
-                #operators.dense_layer: {'prob': 1},
-                # operators.input_layer: {'prob': 1},	
-                operators.conv_layer: {'prob': 1},	
-                # operators.max_pool_layer: {'prob': 1},	
-                # operators.avg_pool_layer: {'prob': 1},	
-                # operators.concat_func: {'prob': 1},	
-                # operators.sum_func: {'prob': 1},	
-                # operators.conv_block: {'prob': 1},	
-                # operators.res_block: {'prob': 1},	
-                # operators.sqeeze_excitation_block: {'prob': 1},	
+                operators.dense_layer: {'prob': 1},
+                # operators.input_layer: {'prob': 1},
+                # operators.conv_layer: {'prob': 1},
+                # operators.max_pool_layer: {'prob': 1},
+                # operators.avg_pool_layer: {'prob': 1},
+                # operators.concat_func: {'prob': 1},
+                # operators.sum_func: {'prob': 1},
+                # operators.conv_block: {'prob': 1},
+                # operators.res_block: {'prob': 1},
+                # operators.sqeeze_excitation_block: {'prob': 1},
                 # operators.identity_block: {'prob': 1}, # TODO replace this with info from operator_dict?
             }
         else:


### PR DESCRIPTION
1. Clean up evaluate() in block.py
- separate in two main cases: 
tensorblock_flag == True: self.tensorflow_evaluate(); 
tensorblock_flag == False: self.non_tensorflow_evaluate()
- both function calls helper function self.calculate_func_args_inputs() to calculate func/args/inputs in the active_nodes

2. Add loggings in genome.py for "Input/output dtype is incompatible with operator functions" errors

3. Clean up tensorblock_evaluate() in block.py
- Before cleaning up, large_dataset and non-large_dataset has many repeating code
- After clean up, these two cases got combined together, reducing redundant code 

4. Clean up some comments, add some logging in block.py